### PR TITLE
docs(docker): fix docker compose typo

### DIFF
--- a/docs/guides/env/how-to-properly-update-env.mdx
+++ b/docs/guides/env/how-to-properly-update-env.mdx
@@ -26,7 +26,7 @@ If you are running SnailyCAD standalone, you can simply press `CTRL+C` in the te
 If you are running SnailyCAD with Docker, you can stop SnailyCAD by running the following command:
 
 ```bash
-docker compose -f production.docker compose.yml down
+docker compose -f production.docker-compose.yml down
 ```
 
   </TabItem>
@@ -55,7 +55,7 @@ node scripts/copy-env.mjs --client --api && yarn turbo run build --filter="{pack
 If you are running SnailyCAD with Docker, you can run the following command to rebuild the client:
 
 ```bash
-node scripts/copy-env.mjs --client --api && docker compose -f production.docker compose.yml build
+node scripts/copy-env.mjs --client --api && docker compose -f production.docker-compose.yml build
 ```
 
   </TabItem>
@@ -78,7 +78,7 @@ yarn run concurrently "yarn workspace @snailycad/client start" "yarn workspace @
 If you are running SnailyCAD with Docker, you can run the following command to start SnailyCAD:
 
 ```bash
-docker compose -f production.docker compose.yml up -d
+docker compose -f production.docker-compose.yml up -d
 ```
 
   </TabItem>

--- a/docs/guides/env/reference.mdx
+++ b/docs/guides/env/reference.mdx
@@ -191,7 +191,7 @@ DOMAIN="example.com"
 SECURE_COOKIES_FOR_IFRAME="false"
 
 # The port of which the API will run on. Default: 8080
-# When using Docker, make sure to change this in the `production.docker compose.yml` file too.
+# When using Docker, make sure to change this in the `production.docker-compose.yml` file too.
 PORT_API=8080
 
 # The port of which the client will run on. Default: 3000

--- a/docs/guides/product/how-set-custom-sounds.mdx
+++ b/docs/guides/product/how-set-custom-sounds.mdx
@@ -46,7 +46,7 @@ If you are running SnailyCAD standalone, you can simply press `CTRL+C` in the te
 If you are running SnailyCAD with Docker, you can stop SnailyCAD by running the following command:
 
 ```bash
-docker compose -f production.docker compose.yml down
+docker compose -f production.docker-compose.yml down
 ```
 
   </TabItem>
@@ -81,7 +81,7 @@ yarn turbo run build --filter="{packages/**/**}" && yarn turbo run build --filte
 If you are running SnailyCAD with Docker, you can run the following command to rebuild the client:
 
 ```bash
-docker compose -f production.docker compose.yml build
+docker compose -f production.docker-compose.yml build
 ```
 
   </TabItem>
@@ -102,7 +102,7 @@ yarn run concurrently "yarn workspace @snailycad/client start" "yarn workspace @
 If you are running SnailyCAD with Docker, you can run the following command to start SnailyCAD:
 
 ```bash
-docker compose -f production.docker compose.yml up -d
+docker compose -f production.docker-compose.yml up -d
 ```
 
   </TabItem>

--- a/docs/guides/product/how-to-install-custom-fonts.mdx
+++ b/docs/guides/product/how-to-install-custom-fonts.mdx
@@ -71,7 +71,7 @@ yarn turbo run build --filter="{packages/**/**}" && yarn turbo run build --filte
 If you are running SnailyCAD with Docker, you can run the following command to rebuild the client:
 
 ```bash
-docker compose -f production.docker compose.yml build
+docker compose -f production.docker-compose.yml build
 ```
 
   </TabItem>
@@ -92,7 +92,7 @@ yarn run concurrently "yarn workspace @snailycad/client start" "yarn workspace @
 If you are running SnailyCAD with Docker, you can run the following command to start SnailyCAD:
 
 ```bash
-docker compose -f production.docker compose.yml up -d
+docker compose -f production.docker-compose.yml up -d
 ```
 
   </TabItem>

--- a/docs/installations/methods/docker.mdx
+++ b/docs/installations/methods/docker.mdx
@@ -148,7 +148,7 @@ DOMAIN="example.com"
 SECURE_COOKIES_FOR_IFRAME="false"
 
 # The port of which the API will run on. Default: 8080
-# When using Docker, make sure to change this in the `production.docker compose.yml` file too.
+# When using Docker, make sure to change this in the `production.docker-compose.yml` file too.
 PORT_API=8080
 
 # The port of which the client will run on. Default: 3000
@@ -195,7 +195,7 @@ This command must **always** be run after changing the `.env` file
 :::
 
 ```bash
-docker compose -f production.docker compose.yml build
+docker compose -f production.docker-compose.yml build
 ```
 
 ### 5. Starting SnailyCADv4
@@ -206,14 +206,14 @@ _**Note:** When running the command for the fist time, this will
 pull down all services from the Docker Hub. This can take a few minutes._
 
 ```bash
-docker compose -f production.docker compose.yml up -d
+docker compose -f production.docker-compose.yml up -d
 ```
 
 :::tip Docker tips
 
-- **Stop SnailyCADv4:** enter `docker compose -f production.docker compose.yml down` in a command prompt/terminal in the directory where you installed the CAD and wait for the services to stop.
+- **Stop SnailyCADv4:** enter `docker compose -f production.docker-compose.yml down` in a command prompt/terminal in the directory where you installed the CAD and wait for the services to stop.
 
-- **View SnailyCADv4 logs:** enter `docker compose -f production.docker compose.yml logs` in a command prompt/terminal in the directory where you installed the CAD.
+- **View SnailyCADv4 logs:** enter `docker compose -f production.docker-compose.yml logs` in a command prompt/terminal in the directory where you installed the CAD.
 
 :::
 

--- a/docs/installations/methods/standalone.mdx
+++ b/docs/installations/methods/standalone.mdx
@@ -179,7 +179,7 @@ DOMAIN="example.com"
 SECURE_COOKIES_FOR_IFRAME="false"
 
 # The port of which the API will run on. Default: 8080
-# When using Docker, make sure to change this in the `production.docker compose.yml` file too.
+# When using Docker, make sure to change this in the `production.docker-compose.yml` file too.
 PORT_API=8080
 
 # The port of which the client will run on. Default: 3000

--- a/docs/installations/updating/methods/docker.mdx
+++ b/docs/installations/updating/methods/docker.mdx
@@ -7,7 +7,7 @@ Find out how to update SnailyCADv4 manually when using the docker installation m
 First, shut down your SnailyCAD instance, to do so run the following command:
 
 ```bash
-docker compose -f production.docker compose.yml down
+docker compose -f production.docker-compose.yml down
 ```
 
 ### 2. Update local code
@@ -46,7 +46,7 @@ If there's something that needs to be changed in the .env file, make sure to do 
 Now we must build all the packages & apps again. _(client, schemas, config, types)_
 
 ```sh
-docker compose -f production.docker compose.yml build
+docker compose -f production.docker-compose.yml build
 ```
 
 ### 6. Start SnailyCAD
@@ -54,5 +54,5 @@ docker compose -f production.docker compose.yml build
 To bring the CAD back up run the following command:
 
 ```bash
-docker compose -f production.docker compose.yml up -d
+docker compose -f production.docker-compose.yml up -d
 ```


### PR DESCRIPTION
This PR fixes a typo for docker instructions. I suppose it was removed by mistake when replacing the legacy `docker-compose` Docker plugin with the `docker compose` command.