### PR TITLE
Update index.mdx

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -11,7 +11,7 @@ It is built with scale in mind and with the latest technologies such as Next.js,
 
 - OS: `Windows` or `Linux` (pref. Ubuntu, Debian)
 - vCPU's/CPU's: `>=2`
-- RAM: `>=2gb`
+- RAM: `>=2gb` (>=4gb if running PostgreSQL on the same hardware)
 - Proxy: `NGINX` or `Apache`
 - **Experience with the Command Prompt/Terminal is recommended**
 


### PR DESCRIPTION
Add 4gb notice if running postgreSQL on same hardware as SnailyCAD to avoid running out of memory error from being caused when someone is buying a VPS