### PR TITLE
Update standalone.mdx

### DIFF
--- a/docs/installations/methods/standalone.mdx
+++ b/docs/installations/methods/standalone.mdx
@@ -129,6 +129,10 @@ When changing something in the `.env` file after the installation process, make 
 - `ENCRYPTION_TOKEN`: Used to generate encrypted values. **Must be 32 characters long**
 - `DATABASE_URL`: **Do not change unless you know what you're doing!**
 
+:::caution
+Do **not** use `localhost` for Accessing SnailyCAD. It will not work!
+:::
+
 :::tip
 **Please take a few minutes and read the [in-depth guide for each environment variable here](/docs/guides/env/reference).**
 :::


### PR DESCRIPTION
Added it to the documentation saying you cant use localhost earlier in the setup process where users may enter in localhost. (Like me)