### PR TITLE
🧹 Update NGINX Config

### DIFF
--- a/docs/installations/reverse-proxies/nginx.mdx
+++ b/docs/installations/reverse-proxies/nginx.mdx
@@ -11,6 +11,10 @@ import TabItem from "@theme/TabItem";
 This guide targets Windows and Linux (Debian-based) users.
 :::
 
+:::warning
+Ports `80` and `443` must be open on your server. If you are using a firewall, you must allow these ports.
+:::
+
 ## Terminology
 
 - **API**: The API of SnailyCAD - the backend.
@@ -648,7 +652,8 @@ server {
   # ...
 
   # Previous was `listen 80;`:
-  listen 443 ssl http2;
+  listen 443 ssl;
+  http2 on;
 
   # Add the following lines:
   ssl_certificate C:/ssl/xxxxxxxxxxxxx-chain.pem; # The path to your SSL certificate (-chain.pem file)


### PR DESCRIPTION
This falls in line with newer versions of NGINX, requiring the new line (`http2 on;`) to be added to the config, and remove http2 from the listener.