### PR TITLE
Update cf-tunnels.mdx

### DIFF
--- a/docs/installations/reverse-proxies/cf-tunnels.mdx
+++ b/docs/installations/reverse-proxies/cf-tunnels.mdx
@@ -13,7 +13,7 @@ This guide will show you how to use Cloudflare Tunnels for SnailyCAD. With Cloud
 ### 1. Login to Cloudflare
 
 1. Navigate to the [Cloudflare Zero Trust Dashboard](https://one.dash.cloudflare.com) and login with your Cloudflare account.
-2. In the left sidebar, click on `Access` then `Tunnels` (also in the sidebar).
+2.  in the dashboard under your account → Zero Trust (one.dash.cloudflare.com) → Networks  → Tunnels
 
 ## 2. Create a tunnel for system
 


### PR DESCRIPTION
Note cloudflare Tunnels   has beed moved from access to  ..→  in the dashboard under your account → Zero Trust (one.dash.cloudflare.com) → Networks  → Tunnels